### PR TITLE
Change form data order and add content-type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/uploader",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Client side uploader package",
   "main": "./dist/index.js",
   "scripts": {
@@ -31,5 +31,6 @@
     "request-promise": "^4.2.2",
     "sinon": "^4.0.1"
   },
-  "homepage": "https://github.com/fiverr/uploader_package#readme"
+  "homepage": "https://github.com/fiverr/uploader_package#readme",
+  "dependencies": {}
 }

--- a/src/service.js
+++ b/src/service.js
@@ -9,13 +9,14 @@ class UploaderService {
     upload({formData = new FormData(), field, additionalFields, customHeaders}) {
         return new Promise((resolve, reject) => {
 
-            formData.append(field, this.file);
-
             if (additionalFields) {
                 for (const fieldName in additionalFields) {
                     formData.append(fieldName, additionalFields[fieldName]);
                 }
             }
+
+            formData.append('content-type', this.file.type);
+            formData.append(field, this.file);
 
             this.xhr.open('POST', this.url);
 


### PR DESCRIPTION
When posting a file to S3, the form data fields order is important... This should allow to upload to s3 using policy