### PR TITLE
File meta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/uploader",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Client side uploader package",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const KILOBYTE = 1000,
 
 class Uploader {
 
-    constructor({url, uploads = {}, maxFiles = 10, headers = {}, optionsObject = {}, updateCb, onLoad, maxFilesText = ''}) {
+    constructor({url, uploads = {}, maxFiles = 10, headers = {}, optionsObject = {}, updateCb, onLoad, onError, maxFilesText = ''}) {
 
         Object.assign(this, {
             uploads,
@@ -16,11 +16,13 @@ class Uploader {
             fileCounter: Object.keys(uploads).length,
             updateCb,
             onLoad,
+            onError,
             maxFilesText
         });
 
         this.onAttach = this.onAttach.bind(this);
         this.onAbort = this.onAbort.bind(this);
+        this.getFiles = this.getFiles.bind(this)
     }
 
     static itemId(name) {
@@ -66,7 +68,7 @@ class Uploader {
 
     static getFileReady(file) {
 
-        const fileMeta = file,
+        const fileMeta = { name: file.name, size: file.size },
             fullName = Uploader.stripNameFromExtension(fileMeta.name),
             fileSize = Uploader.prettyFileSize(fileMeta.size);
 
@@ -75,6 +77,7 @@ class Uploader {
         fileMeta.fileSize = fileSize;
         fileMeta.progress = 0;
         fileMeta.loaded = false;
+        fileMeta.uploadStartTime = Date.now();
 
         return fileMeta;
     }
@@ -91,7 +94,7 @@ class Uploader {
         const files = {};
         for (const upload in this.uploads) {
             if (this.uploads[upload].hasOwnProperty('file')) {
-                files[upload] = this.uploads[upload].file;
+                files[upload] = this.uploads[upload].meta;
             }
         }
         return files;
@@ -117,7 +120,7 @@ class Uploader {
 
         ids.forEach((id) => {
             this.uploads[id].onProgress((progress) => {
-                this.updateFileObject(id, 'progress', progress);
+                this.updateFileMeta(id, 'progress', progress);
                 this.update();
             });
 
@@ -136,16 +139,19 @@ class Uploader {
                     }
 
                     this.updateFileObject(id, 'loaded', true);
-                    this.updateFileObject(id, 'onLoadResponse', result[id]);
+                    this.updateFileMeta(id, 'onLoadResponse', result[id]);
             
                     this.onLoad && this.onLoad(result, this.getFiles());
+                })
+                .catch((error) => {
+                    this.onError && this.onError({attachmentName: id, error});
                 });
         });
     }
 
-    updateFileObject(id, field, value) {
-        if (this.uploads[id] && this.uploads[id].hasOwnProperty('file')) {
-            this.uploads[id].file[field] = value;
+    updateFileMeta(id, field, value) {
+        if (this.uploads[id] && this.uploads[id].hasOwnProperty('meta')) {
+            this.uploads[id].meta[field] = value;
         }
     }
 
@@ -181,6 +187,7 @@ class Uploader {
             }
 
             this.uploads[fileId] = currentFile;
+            this.uploads[fileId].meta = fileMeta;
         }
 
         return fileIds;

--- a/src/index_spec.js
+++ b/src/index_spec.js
@@ -1,6 +1,6 @@
 const sinon = require('sinon');
 const Uploader = require('./index.js');
-const FileAPI = require('file-api')
+const FileAPI = require('file-api');
 const {expect} = require('chai');
 const {describe} = require('mocha');
 
@@ -119,7 +119,7 @@ describe('Uploader', () => {
                     uploader = new Uploader({url: 'www.fiverr.com', maxFilesText: 'MAX', uploads: {}, maxFiles: 2,  headers: {}, optionsObject: {}, updateCb: () => {}}); 
                     fileList = new FileAPI.FileList([file, file, file, file, file]);
                     uploader.onAttach(fileList);
-                    expect(uploader.uploads['file_abcsongtxt4'].file.hasOwnProperty('error')).to.equal(true);                
+                    expect(uploader.uploads['file_abcsongtxt4'].meta.hasOwnProperty('error')).to.equal(true);                
                 });
     
                 it('Should return false when the number of files is greater than the max value', () => {

--- a/src/service.js
+++ b/src/service.js
@@ -2,6 +2,7 @@ class UploaderService {
     constructor(url, file, headers) {
         this.url = url;
         this.file = file;
+        this.meta = {};
         this.xhr = new XMLHttpRequest();
         this.headers = headers;
     }


### PR DESCRIPTION
Until now metadata (name, size, progress, loaded, onLoadResponse...) on file are stored on original File Object.

Problem: Mutation of this object by uploader package is not predicable from outside, and changes can be overriden from outside as well.

Solution: don't use the original File object, but rather use a private metadata object to store all these metadata info 